### PR TITLE
Example on how we can show the Nightly Update URL on the Nightly Builds page

### DIFF
--- a/language/en-GB/en-GB.plg_content_nightlybuilds.ini
+++ b/language/en-GB/en-GB.plg_content_nightlybuilds.ini
@@ -8,5 +8,5 @@ PLG_CONTENT_NIGHTLYBUILDS_BUILD_BRANCH="These packages were built based on %1$s 
 PLG_CONTENT_NIGHTLYBUILDS_BUILD_TIME="These packages were last built: %s"
 PLG_CONTENT_NIGHTLYBUILDS_REF_BRANCH="branch"
 PLG_CONTENT_NIGHTLYBUILDS_REF_COMMIT="commit"
-PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER="To allways use the last version and test the update component you can use this update server: %s"
+PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER="To always use the last version and test the update component you can use this custom update server: %s"
 PLG_CONTENT_NIGHTLYBUILDS_XML_DESCRIPTION="This plugin lists the nightly build packages."

--- a/language/en-GB/en-GB.plg_content_nightlybuilds.ini
+++ b/language/en-GB/en-GB.plg_content_nightlybuilds.ini
@@ -8,4 +8,5 @@ PLG_CONTENT_NIGHTLYBUILDS_BUILD_BRANCH="These packages were built based on %1$s 
 PLG_CONTENT_NIGHTLYBUILDS_BUILD_TIME="These packages were last built: %s"
 PLG_CONTENT_NIGHTLYBUILDS_REF_BRANCH="branch"
 PLG_CONTENT_NIGHTLYBUILDS_REF_COMMIT="commit"
+PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER="To allways use the last version and test the update component you can use this update server: %s"
 PLG_CONTENT_NIGHTLYBUILDS_XML_DESCRIPTION="This plugin lists the nightly build packages."

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -151,7 +151,7 @@ class PlgContentNightlyBuilds extends JPlugin
 			$html .= sprintf(
 					'<p>%s</p>',
 					JText::sprintf(
-						'PLG_CONTENT_NIGHTLYBUILDS_BUILD_UDATESERVER',
+						'PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER',
 						JHtml::_('link', $updateserver, $updateserver, ['class' => 'alert-link'])
 					)
 				);

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -100,6 +100,20 @@ class PlgContentNightlyBuilds extends JPlugin
 			$commitSha    = file_exists("$nightlyDir/$branch.txt") ? trim(file_get_contents("$nightlyDir/$branch.txt")) : false;
 			$linkedBranch = $commitSha;
 
+			// Set the updateserver per branch defaults to the next patch updateserver
+			switch ($branch)
+			{
+				case '3.7' :
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
+					break;
+				case '4.0' :
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
+					break;
+				default :
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
+					break;
+			}
+
 			/*
 			 * Figure out our linked branch if the commit SHA doesn't exist.
 			 *
@@ -113,17 +127,14 @@ class PlgContentNightlyBuilds extends JPlugin
 				if ($branch == JVersion::RELEASE)
 				{
 					$linkedBranch = 'staging';
-					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
 				}
 				elseif ($branch == '3.7')
 				{
 					$linkedBranch = '3.7.x';
-					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 				}
 				else
 				{
 					$linkedBranch = "$branch-dev";
-					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 				}
 			}
 
@@ -146,15 +157,16 @@ class PlgContentNightlyBuilds extends JPlugin
 			}
 
 			$html .= '</ul>';
-			$html .= '<p></p>';
 
+			// Display the Updateserver
+			$html .= '<p></p>';
 			$html .= sprintf(
-					'<p>%s</p>',
-					JText::sprintf(
-						'PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER',
-						JHtml::_('link', $updateserver, $updateserver, ['class' => 'alert-link'])
-					)
-				);
+				'<p>%s</p>',
+				JText::sprintf(
+					'PLG_CONTENT_NIGHTLYBUILDS_UDATESERVER',
+					JHtml::_('link', $updateserver, $updateserver, ['class' => 'alert-link'])
+				)
+			);
 
 			$html .= JHtml::_('bootstrap.endSlide');
 		}

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -104,7 +104,7 @@ class PlgContentNightlyBuilds extends JPlugin
 			$pieces  = explode(".", $version);
 
 			$minor = $pieces[0] . "." . ($pieces[1] + 1);
-			$major = ($pieces[0] + 1) . "." . "0";
+			$major = ($pieces[0] + 1) . ".0";
 
 			// Set the updateserver per branch defaults to the next patch updateserver
 			switch ($branch)

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -100,13 +100,19 @@ class PlgContentNightlyBuilds extends JPlugin
 			$commitSha    = file_exists("$nightlyDir/$branch.txt") ? trim(file_get_contents("$nightlyDir/$branch.txt")) : false;
 			$linkedBranch = $commitSha;
 
+			$version = JVersion::RELEASE;
+			$pieces  = explode(".", $version);
+
+			$minor = $pieces[0] . "." . ($pieces[1] + 1);
+			$major = ($pieces[0] + 1) . "." . "0";
+
 			// Set the updateserver per branch defaults to the next patch updateserver
 			switch ($branch)
 			{
-				case '3.7' :
+				case $minor :
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 					break;
-				case '4.0' :
+				case $major :
 					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 					break;
 				default :

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -113,17 +113,17 @@ class PlgContentNightlyBuilds extends JPlugin
 				if ($branch == JVersion::RELEASE)
 				{
 					$linkedBranch = 'staging';
-					$updateserver = 'https://update.joomla.org/nightlies/next_patch_list.xml';
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_patch_list.xml';
 				}
 				elseif ($branch == '3.7')
 				{
 					$linkedBranch = '3.7.x';
-					$updateserver = 'https://update.joomla.org/nightlies/next_minor_list.xml';
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_minor_list.xml';
 				}
 				else
 				{
 					$linkedBranch = "$branch-dev";
-					$updateserver = 'https://update.joomla.org/nightlies/next_major_list.xml';
+					$updateserver = 'https://update.joomla.org/core/nightlies/next_major_list.xml';
 				}
 			}
 

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -113,14 +113,17 @@ class PlgContentNightlyBuilds extends JPlugin
 				if ($branch == JVersion::RELEASE)
 				{
 					$linkedBranch = 'staging';
+					$updateserver = 'https://update.joomla.org/nightlies/next_patch_list.xml';
 				}
 				elseif ($branch == '3.7')
 				{
 					$linkedBranch = '3.7.x';
+					$updateserver = 'https://update.joomla.org/nightlies/next_minor_list.xml';
 				}
 				else
 				{
 					$linkedBranch = "$branch-dev";
+					$updateserver = 'https://update.joomla.org/nightlies/next_major_list.xml';
 				}
 			}
 
@@ -143,6 +146,15 @@ class PlgContentNightlyBuilds extends JPlugin
 			}
 
 			$html .= '</ul>';
+			$html .= '<p></p>';
+
+			$html .= sprintf(
+					'<p>%s</p>',
+					JText::sprintf(
+						'PLG_CONTENT_NIGHTLYBUILDS_BUILD_UDATESERVER',
+						JHtml::_('link', $updateserver, $updateserver, ['class' => 'alert-link'])
+					)
+				);
 
 			$html .= JHtml::_('bootstrap.endSlide');
 		}


### PR DESCRIPTION
Example on how we can show the Nightly Update URL on the Nightly Builds page

This is only relevant if we push this changes: https://github.com/joomla/update.joomla.org/pull/16
