### PR TITLE
Add yet another special case #3

### DIFF
--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -127,6 +127,7 @@ class PlgContentNightlyBuilds extends JPlugin
 			 * If $branch != JVersion::RELEASE then we're displaying "$branch-dev"
 			 *
 			 * And a special case for 3.7 because it's named differently, "3.7.x"
+			 * and a special case for 3.8 because it's named differently, "3.8.x"
 			 */
 			if (!$linkedBranch)
 			{

--- a/nightlybuilds.php
+++ b/nightlybuilds.php
@@ -138,6 +138,10 @@ class PlgContentNightlyBuilds extends JPlugin
 				{
 					$linkedBranch = '3.7.x';
 				}
+				elseif ($branch == '3.8')
+				{
+					$linkedBranch = '3.8.x';
+				}
 				else
 				{
 					$linkedBranch = "$branch-dev";


### PR DESCRIPTION
Seems the 3.8 branch doesn't use the -dev suffix either. Add yet another special case so the plugin will process this right.

Curse you @wilsonge, curse you and your inconsistencies... :stuck_out_tongue_winking_eye:

@mbabker https://github.com/joomla-projects/plg_content_nightlybuilds/issues/3